### PR TITLE
GeoBlacklight 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ $ cd /usr/local/solr && bin/solr restart
 ```
 
 ### Release Version
-B1G Geoportal Version 1.8.12 / GeoBlacklight 1.8.0
+B1G Geoportal Version 2.0.0 / GeoBlacklight 2.0.0

--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<schema name="geoblacklight-schema" version="1.6">
+<schema name="geoblacklight-schema" version="2.0">
   <uniqueKey>layer_slug_s</uniqueKey>
   <fields>
     <field name="_version_" type="long"   stored="true" indexed="true"/>
@@ -65,6 +65,8 @@
     <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
+    <dynamicField name="*_bboxtype" type="bbox" stored="true" indexed="true"/>
+
   </fields>
 
   <types>
@@ -145,6 +147,11 @@
 
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
+    <!-- Adding field type for bboxField that enables, among other things, overlap ratio calculations -->
+    <fieldType name="bbox" class="solr.BBoxField"
+           geo="true" distanceUnits="kilometers" numberType="pdouble" />
+    <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
+
 
   </types>
 
@@ -188,4 +195,7 @@
   <copyField source="dct_provenance_s" dest="suggest"/>
   <copyField source="dc_subject_sm" dest="suggest"/>
   <copyField source="dct_spatial_sm" dest="suggest"/>
+
+  <!-- for bbox value -->
+  <copyField source="solr_geom" dest="solr_bboxtype"/>
 </schema>

--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -242,7 +242,7 @@
       <str name="name">mySuggester</str>
       <str name="lookupImpl">FuzzyLookupFactory</str>
       <str name="suggestAnalyzerFieldType">textSuggest</str>
-      <str name="buildOnCommit">false</str>
+      <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
     </lst>
   </searchComponent>


### PR DESCRIPTION
This PR includes schema and solrconfig changes for GeoBlacklight 2.0. Biggest feature is the addition of fields to support bbox relevancy ratio. Updates suggest handler to build on commit (as GBL and BL default).

Tested successfully locally with Solr 7.7.1.