### PR TITLE
Schema: add date range support

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -44,6 +44,14 @@
 
     <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
+    <!-- date range (_dr...) (for faster AND better range queries) -->
+    <dynamicField name="*_dri" type="dateRange" stored="false" indexed="true" multiValued="false"/>
+    <dynamicField name="*_drim" type="dateRange" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_drs" type="dateRange" stored="true" indexed="false" multiValued="false"/>
+    <dynamicField name="*_drsm" type="dateRange" stored="true" indexed="false" multiValued="true"/>
+    <dynamicField name="*_drsi" type="dateRange" stored="true" indexed="true" multiValued="false"/>
+    <dynamicField name="*_drsim" type="dateRange" stored="true" indexed="true" multiValued="true"/>
+
     <!-- Spatial field types:
 
          Solr3:


### PR DESCRIPTION
Addresses https://github.com/BTAA-Geospatial-Data-Project/geoportal/issues/129

Date range support is a future goal of the Geoportal. A corresponding, exploratory, Geoportal [feature branch](https://github.com/BTAA-Geospatial-Data-Project/geoportal/tree/feature/date-range-support) has already been cut.

This change copies the Sameva Project's implementation of dateRange fields. As this just adds the dynamic field definitions here, we can merge this change and run it on dev and prod immediately. Once the new schema is in place @karenmajewicz can begin the task of updating our records with date range values.

Creating the PR to get this work onto @mberkowski todo list.