### PR TITLE
GBL v4 - Solr v8 (latest) - config changes

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -5,6 +5,10 @@
     <field name="_version_" type="long"   stored="true" indexed="true"/>
     <field name="timestamp" type="date"   stored="true" indexed="true" default="NOW"/>
 
+    <!-- core generated fields -->
+    <field name="text" type="text_en" stored="false" indexed="true" multiValued="true"
+                       termVectors="true" termPositions="true" termOffsets="true" />
+
     <!-- Kithe -->
     <!-- id is the unique key -->
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
@@ -12,15 +16,29 @@
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <!-- date_created_dtsi -->
     <dynamicField name="*_dtsi" type="pdate" stored="true" indexed="true" multiValued="false"/>
-
     <!-- END Kithe -->
 
-    <!-- GeoBlacklight -->
+    <!-- GEOMG -->
     <field name="geomg_id_s" type="string" stored="true" indexed="true" required="true"/>
+    <!-- END GEOMG -->
 
-    <!-- core generated fields -->
-    <field name="text" type="text_en" stored="false" indexed="true" multiValued="true"
-                       termVectors="true" termPositions="true" termOffsets="true" />
+    <!-- GeoBlacklight -->
+    <!-- Spatial Field Type: Represents the exent of the resource and powers map search functionality.
+      Value can be any valid WKT or ENVELOPE String:
+        <field name="locn_geometry">POLYGON((1 8, 1 9, 2 9, 2 8, 1 8))</field>
+        <field name="locn_geometry">ENVELOPE(-117.312, -115.39, 84.31, 83.1)</field> -->
+    <field name="locn_geometry" type="location_geo3d" stored="true" indexed="true"/>
+
+    <!-- Spatial Field Type: The bounding box of the resource. Used in overlap ratio boosting.
+      Value must be an ENVELOPE String:
+        <field name="dcat_bbox">ENVELOPE(-117.312, -115.39, 84.31, 83.1)</field> -->
+    <field name="dcat_bbox" type="location_rpt" stored="true" indexed="true"/>
+
+    <!-- Spatial Field Type: Used to display the center point of a resource. -->
+    <field name="dcat_centroid" type="location" stored="true" indexed="true"/>
+
+    <!-- Spatial Field Type: Internal field used for overlap ratio boosting. -->
+    <field name="solr_bboxtype" type="bbox" stored="true" indexed="true"/>
 
     <!-- dynamic field with simple types by suffix -->
     <dynamicField name="*_b"    type="boolean" stored="true"  indexed="true"/>
@@ -55,31 +73,8 @@
     <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
     <!-- date range (_dr...) (for faster AND better range queries) -->
-    <dynamicField name="*_dri" type="dateRange" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_drim" type="dateRange" stored="false" indexed="true" multiValued="true"/>
-    <dynamicField name="*_drs" type="dateRange" stored="true" indexed="false" multiValued="false"/>
-    <dynamicField name="*_drsm" type="dateRange" stored="true" indexed="false" multiValued="true"/>
-    <dynamicField name="*_drsi" type="dateRange" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_drsim" type="dateRange" stored="true" indexed="true" multiValued="true"/>
 
-    <!-- Spatial field types:
-
-         Solr3:
-           <field name="my_pt">83.1,-117.312</field>
-             as (y,x)
-
-         Solr4:
-
-           <field name="my_bbox">-117.312 83.1 -115.39 84.31</field>
-             as (W S E N)
-
-           <field name="my_geometry">ENVELOPE(-117.312, -115.39, 84.31, 83.1)</field>
-             as (W E N S)
-
-           <field name="my_jts">POLYGON((1 8, 1 9, 2 9, 2 8, 1 8))</field>
-             as WKT for point, linestring, polygon
-
-      -->
     <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
@@ -151,7 +146,6 @@
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
@@ -161,23 +155,27 @@
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.StandardFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
 
     <!-- Spatial field types -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_d"/>
-
+    <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
+    <fieldType name="location_geo3d"
+      class="solr.SpatialRecursivePrefixTreeFieldType"
+      spatialContextFactory="Geo3D"
+      prefixTree="s2"
+      geo="true"
+      maxDistErr="0.001"
+      planetModel="WGS84"/>
+
     <!-- Adding field type for bboxField that enables, among other things, overlap ratio calculations -->
     <fieldType name="bbox" class="solr.BBoxField"
            geo="true" distanceUnits="kilometers" numberType="pdouble" />
     <fieldType name="pdouble" class="solr.DoublePointField" docValues="true"/>
-
-
   </types>
 
   <!-- for scoring formula -->
@@ -224,5 +222,8 @@
   <copyField source="dct_spatial_sm" dest="suggest"/>
 
   <!-- for bbox value -->
-  <copyField source="locn_geometry" dest="solr_bboxtype"/>
+  <copyField source="dcat_bbox" dest="solr_bboxtype"/>
+
+  <!-- for GEOMG reporting -->
+  <copyField source="date_created_dtsi" dest="date_created_drsim"/>
 </schema>

--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -27,7 +27,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.1</luceneMatchVersion>
+  <luceneMatchVersion>7.6</luceneMatchVersion>
 
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
@@ -83,9 +83,9 @@
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
-    <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>
-    <queryResultCache class="solr.LRUCache" size="512" initialSize="512" autowarmCount="0"/>
-    <documentCache class="solr.LRUCache" size="512" initialSize="512" autowarmCount="0"/>
+    <filterCache class="solr.CaffeineCache" size="512" initialSize="512" autowarmCount="0" async="true"/>
+    <queryResultCache class="solr.CaffeineCache" size="512" initialSize="512" autowarmCount="0" async="true"/>
+    <documentCache class="solr.CaffeineCache" size="512" initialSize="512" autowarmCount="0" async="true"/>
     <enableLazyFieldLoading>true</enableLazyFieldLoading>
     <queryResultWindowSize>20</queryResultWindowSize>
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>


### PR DESCRIPTION
GeoBlacklight v4 will require Solr v8.3 (min) due to new java spatial library field definitions. We should just use the latest release, currently: v8.11.1.

Fixes #7