### PR TITLE
added in replication and correct core name

### DIFF
--- a/conf/solrconfig.xml
+++ b/conf/solrconfig.xml
@@ -76,8 +76,7 @@
     </lst>
   </requestHandler>
   -->
-  <!-- ANSIBLE-MANAGED-REPLICATION KEEP THIS LINE -->
-
+  <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
   <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        Query section - these settings control query time things like caches
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->

--- a/core.properties
+++ b/core.properties
@@ -1,6 +1,6 @@
 #Written by CorePropertiesLocator
 #Fri Apr 29 18:26:48 UTC 2016
-name=production
+name=geomg
 config=solrconfig.xml
 schema=schema.xml
 dataDir=data


### PR DESCRIPTION
Previously, we added in the replication handler via ansible. We also ran multiple cores and thus needed to specify the core name. Instead, we can now set these by default in the solr core.

closes #11 #12